### PR TITLE
Callback fix

### DIFF
--- a/busyApp/src/devBusyAsyn.c
+++ b/busyApp/src/devBusyAsyn.c
@@ -206,8 +206,9 @@ static void interruptCallback(void *drvPvt, asynUser *pasynUser,
         "%s devAsynBusy::interruptCallback new value=%d\n",
         pr->name, value);
     /* If the current value of the record is 1 and the new value is 0 then post monitors
-     * and call recGblFwdLink */
-    if ((pr->val == 1) && (value == 0)) {
+     * and call recGblFwdLink 
+     * Ignore the callback if pr->pact=1 because a write operation is in progress. */
+    if ((pr->pact == 0) && (pr->val == 1) && (value == 0)) {
         /* If the current value of the record is 1 and the new value is 0 then post monitors
         * and call recGblFwdLink */
         asynPrint(pPvt->pasynUser, ASYN_TRACEIO_DEVICE,

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -8,10 +8,10 @@ SUPPORT=/corvette/home/epics/devel
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 
 # ASYN is needed to compile asyn device support
-ASYN=$(SUPPORT)/asyn-4-17
+ASYN=$(SUPPORT)/asyn-4-28
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/corvette/usr/local/epics/base-3.14.12.1
+EPICS_BASE=/corvette/usr/local/epics/base-3.14.12.5
 -include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)
 
 #Capfast users may need the following definitions


### PR DESCRIPTION
This appears to fix the problem of the busy record having VAL=0 when an interruptCallback with value=0 happens after a queueRequest with val=1 but before the queueRequest calls processCallback.
